### PR TITLE
Some changes

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -104,7 +104,7 @@ sub\_id\_types\_supported
 * `op-bound`: the "classical" OpenID Connect identifier. The identifier is built by concatinating the `sub` value, created and maintained by the OP, and the OP's issuer URL.  
     
 did\_methods\_supported
-: OPTIONAL. A JSON array of strings used in conjunction with the identifier type `did`. This metadata element describes whether the client supports the resolution of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array value contains the DID method `method-name` as per [@!decentralized_identifiers]. A full enumeration of DID methods can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]). 
+: OPTIONAL. A JSON array of strings used in conjunction with the identifier type `did`. This metadata element describes whether the client supports the resolution of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array value contains the DID method name as per [@!decentralized_identifiers]. A full enumeration of DID methods can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]). 
 
 [TBD] is this element required if the did subject identifier type is supported?
 
@@ -134,7 +134,7 @@ sub\_id\_types\_supported
 : OPTIONAL. An array of strings. This metadata element describes the subject identifier types supported by the registering client. Valid values MUST be a subset of those that the OP the client is registering with supports, which can be found in respective `sub_id_types_supported` metadata element.
     
 did\_methods\_supported
-: OPTIONAL. An array of strings. This metadata element describes whether the client supports the resolution (point to a definition of did resolution) of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array element contains the DID method `method-name` as per [@!decentralized_identifiers]. A full enumeration can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]) the client supports. 
+: OPTIONAL. An array of strings. This metadata element describes whether the client supports the resolution (point to a definition of did resolution) of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array element contains the DID method name as per [@!decentralized_identifiers]. A full enumeration can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]) the client supports. 
 
 [TBD] is this element required if the did subject identifier type is supported?
 

--- a/spec.md
+++ b/spec.md
@@ -39,7 +39,7 @@ initials = "O."
 surname = "Terbu"
 fullname = "Oliver Terbu"
 #role = "editor"
-organization = "Consensys"
+organization = "ConsenSys"
 %%%
 
 .# Abstract
@@ -97,14 +97,14 @@ TODO
 
 The following section outlines how an OpenID provider can use the following meta-data elements in its openid-configuration as defined in [@!OpenID-Discovery] to advertise the identifier types it supports, which especially includes metadata about portable subject identifiers.
 
-subject\_id\_types\_supported
+sub\_id\_types\_supported
 : OPTIONAL. A JSON array of strings. This metadata element describes the subject identifier types supported by the respective OP. This specification defines the following values:
 * `jwkthumb`: the identifier constitutes the thumbprint of a JWK 
 * `did`: the identifier constitutes a decentralized identifier as defined in [@!decentralized_identifiers]
 * `op-bound`: the "classical" OpenID Connect identifier. The identifier is built by concatinating the `sub` value, created and maintained by the OP, and the OP's issuer URL.  
     
 did\_methods\_supported
-: OPTIONAL. A JSON array of strings used in conjunction with the identifier type `did`. This metadata element describes whether the client supports the resolution of [@!decentralized_identifiers] and further more which decentralized identifier methods. A full enumeration of DID methods can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]). 
+: OPTIONAL. A JSON array of strings used in conjunction with the identifier type `did`. This metadata element describes whether the client supports the resolution of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array value contains the DID method `method-name` as per [@!decentralized_identifiers]. A full enumeration of DID methods can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]). 
 
 [TBD] is this element required if the did subject identifier type is supported?
 
@@ -130,11 +130,11 @@ A non-normative extract from the OP Metadata depicting these elements
 
 The following section outlines the additional metadata elements required for a client to express support for specific identifier types.
 
-subject\_id\_types\_supported
-: OPTIONAL. An array of strings. This metadata element describes the subject identifier types supported by the registering client. Valid values MUST be a subset of those that the OP the client is registering with supports, which can be found in respective `subject_id_types_supported` metadata element.
+sub\_id\_types\_supported
+: OPTIONAL. An array of strings. This metadata element describes the subject identifier types supported by the registering client. Valid values MUST be a subset of those that the OP the client is registering with supports, which can be found in respective `sub_id_types_supported` metadata element.
     
 did\_methods\_supported
-: OPTIONAL. An array of strings. This metadata element describes whether the client supports the resolution (point to a definition of did resolution) of [@!decentralized_identifiers] and further more which decentralized identifier methods (a full enumeration can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]) the client supports. 
+: OPTIONAL. An array of strings. This metadata element describes whether the client supports the resolution (point to a definition of did resolution) of [@!decentralized_identifiers] and further more which decentralized identifier methods. Each array element contains the DID method `method-name` as per [@!decentralized_identifiers]. A full enumeration can be found in the "decentralized identifier method registry" (see [@!did_specs_registry]) the client supports. 
 
 [TBD] is this element required if the did subject identifier type is supported?
 


### PR DESCRIPTION
renamed subject_id_types_supported in sub_id_types_support to better align with the rest of the spec which might fix #10 ;
explicit reference to method-name to avoid confusion with trailing ":" symbols in current DID Spec registry which might fix #5 ;